### PR TITLE
feat(collab): require POST /sessions to input question for use during sessions

### DIFF
--- a/services/collaboration-service/app/rest/sessions.py
+++ b/services/collaboration-service/app/rest/sessions.py
@@ -1,15 +1,27 @@
 
+from http.client import HTTPException
 from fastapi import APIRouter
 from app.schemas.collaboration import CreateSessionRequest, CreateSessionResponse
 from app.core.connection_manager import connection_manager
+from app.core.errors import SessionNotFoundError
+from app.schemas.questions import QuestionBase64Images
 
 router = APIRouter()
 
 @router.post("/", response_model=CreateSessionResponse)
 def create_session(request: CreateSessionRequest):
     user_ids = request.user_ids
-    session_id = connection_manager.init_session(user_ids)
+    question = request.question
+    session_id = connection_manager.init_session(user_ids, question)
     return CreateSessionResponse(session_id=session_id)
+
+@router.get("/{session_id}/question", response_model=QuestionBase64Images)
+def get_session_question(session_id: str):
+    try:
+        question = connection_manager.get_question(session_id)
+        return question
+    except SessionNotFoundError as err:
+        raise HTTPException(status_code=404, detail=err.msg)
 
 
 

--- a/services/collaboration-service/app/rest/sessions.py
+++ b/services/collaboration-service/app/rest/sessions.py
@@ -1,6 +1,5 @@
 
-from http.client import HTTPException
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from app.schemas.collaboration import CreateSessionRequest, CreateSessionResponse
 from app.core.connection_manager import connection_manager
 from app.core.errors import SessionNotFoundError

--- a/services/collaboration-service/app/schemas/collaboration.py
+++ b/services/collaboration-service/app/schemas/collaboration.py
@@ -2,12 +2,14 @@
 from pydantic import BaseModel, conlist
 from typing import List
 from datetime import datetime
+from .questions import QuestionBase64Images
 
 ## TODO: Finalize CreateSessionRequest and CreateSessionResponse 
+## TODO: move to shared_schemas, will need to be duplicated for matching-service
 class CreateSessionRequest(BaseModel):
     user_ids: List[str] = conlist(str, min_length=2, max_length=2)
+    question: QuestionBase64Images
     # created_at: datetime = datetime.now()
-    ## question: Question
 
 class CreateSessionResponse(BaseModel):
     session_id: str

--- a/services/collaboration-service/app/schemas/questions.py
+++ b/services/collaboration-service/app/schemas/questions.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel, Field
+from typing import Optional, List
+
+## TODO: move to shared_schemas, currently duplicated from question-service
+class QuestionBase64Images(BaseModel):
+    """Question model with images as base64 strings - used for API requests/responses"""
+    id: Optional[str] = None
+    name: str
+    description: str
+    difficulty: str
+    topic: str
+    images: Optional[List[str]] = Field(default=None, description="Base64 encoded images")


### PR DESCRIPTION
This pull request adds support for associating a question (including base64-encoded images) with each collaboration session in the `collaboration-service`. Now, when a session is created, a question must be provided and can later be retrieved via a dedicated API endpoint. The changes also introduce a new schema for questions and update relevant API routes and data models accordingly.

**Session Question Association:**

* Updated the `ConnectionManager` class to store a `QuestionBase64Images` object per session and require a question when initializing a session.
* Added a new method `get_question` to `ConnectionManager` for retrieving the question associated with a session, raising a `SessionNotFoundError` if not found.

**API and Schema Updates:**

* Modified the `CreateSessionRequest` schema to require a `question` field of type `QuestionBase64Images`.
* Added a new API endpoint `GET /{session_id}/question` to retrieve the session's question, returning a 404 error if the session does not exist.
* Introduced the `QuestionBase64Images` model in `app/schemas/questions.py` to represent questions with base64-encoded images.