### PR TITLE
fix(fe): missing token id on getLabel call

### DIFF
--- a/frontend/peerprep/app/components/queueupmodal/selectionmodal.tsx
+++ b/frontend/peerprep/app/components/queueupmodal/selectionmodal.tsx
@@ -28,7 +28,7 @@ export default function SelectionModal({ form, handleQueue }: SelectionModalProp
     .catch((error) => {
         console.error("Error fetching labels:", error);
     });
-  }, []);
+  }, [tokenId]);
 
   return (
         <form onSubmit={form.onSubmit((values) => handleQueue(values))}>


### PR DESCRIPTION
Fixes bug from #100 

This pull request updates the label fetching logic in the `SelectionModal` component to use the authenticated user's token and adds error handling for failed requests. The changes ensure that label data is fetched securely and errors are logged for debugging.

Authentication and API integration:

* Imported `useAuth` from `~/context/authContext` and used it to access `tokenId` for authenticated API requests.
* Updated the call to `getLabels` to pass the `tokenId`, ensuring label data is fetched with authentication, and added error handling to log any failures.