### PR TITLE
Fix background to always be dark mode

### DIFF
--- a/frontend/peerprep/app/app.css
+++ b/frontend/peerprep/app/app.css
@@ -7,7 +7,7 @@
 
 html,
 body {
-  @apply dark:bg-gray-950;
+  @apply bg-gray-950;
 
   @media (prefers-color-scheme: dark) {
     color-scheme: dark;


### PR DESCRIPTION
Fixes #97 
Force background to always use dark mode colour.
<img width="1919" height="1034" alt="image" src="https://github.com/user-attachments/assets/39f4a6e9-a8a0-443f-b027-6a089bde1959" />
